### PR TITLE
Fix compilation issues and add BlueRetro pin config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .pio
 ignore/
 *.kate-swp
+/.vscode

--- a/platformio.ini
+++ b/platformio.ini
@@ -59,6 +59,10 @@ board_vendor = "8BitDo"
 build_flags = -DGAMEPAD_OUTPUT=3
 build_src_filter = +<gamepad/ESP32-BLE-Gamepad>
 
+[out-br]
+build_flags = -DGAMEPAD_OUTPUT=3 -D BLUERETRO_MAPPING
+build_src_filter = +<gamepad/ESP32-BLE-Gamepad>
+
 [out-usbradio]
 extends     = out-usb, out-radio
 build_flags = -DGAMEPAD_OUTPUT=4
@@ -123,6 +127,11 @@ extends     = esp32, in-snes, out-bt
 build_src_filter  = ${in-snes.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-bt.build_flags}
 
+[env:esp32-snes-br]
+extends     = esp32, in-snes, out-br
+build_src_filter  = ${in-snes.build_src_filter}  ${out-bt.build_src_filter}
+build_flags = ${in-snes.build_flags} ${out-bt.build_flags}
+
 [env:esp32-snes-debug]
 extends     = esp32, in-snes, out-debug
 build_src_filter  = ${in-snes.build_src_filter}  ${out-debug.build_src_filter}
@@ -166,6 +175,11 @@ lib_deps = https://github.com/OpenRetroPad/Nintendo
 
 [env:esp32-n64-bt]
 extends     = esp32, in-n64-esp32, out-bt
+build_src_filter  = ${in-n64-esp32.build_src_filter}  ${out-bt.build_src_filter}
+build_flags = ${in-n64-esp32.build_flags} ${out-bt.build_flags}
+
+[env:esp32-n64-br]
+extends     = esp32, in-n64-esp32, out-br
 build_src_filter  = ${in-n64-esp32.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-n64-esp32.build_flags} ${out-bt.build_flags}
 
@@ -213,6 +227,11 @@ extends     = esp32, in-genesis, out-bt
 build_src_filter  = ${in-genesis.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-bt.build_flags}
 
+[env:esp32-genesis-br]
+extends     = esp32, in-genesis, out-br
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-bt.build_src_filter}
+build_flags = ${in-genesis.build_flags} ${out-bt.build_flags}
+
 [env:esp32-genesis-debug]
 extends     = esp32, in-genesis, out-debug
 build_src_filter  = ${in-genesis.build_src_filter}  ${out-debug.build_src_filter}
@@ -254,6 +273,11 @@ build_flags = ${common.build_flags} -DGAMEPAD_INPUT=5 -DGAMEPAD_COUNT=4
 
 [env:esp32-psx-bt]
 extends     = esp32, in-psx, out-bt
+build_src_filter  = ${in-psx.build_src_filter}  ${out-bt.build_src_filter}
+build_flags = ${in-psx.build_flags} ${out-bt.build_flags}
+
+[env:esp32-psx-br]
+extends     = esp32, in-psx, out-br
 build_src_filter  = ${in-psx.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-bt.build_flags}
 
@@ -334,6 +358,11 @@ extends     = esp32, in-saturn, out-bt
 build_src_filter  = ${in-saturn.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-bt.build_flags}
 
+[env:esp32-saturn-br]
+extends     = esp32, in-saturn, out-bt
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-bt.build_src_filter}
+build_flags = ${in-saturn.build_flags} ${out-bt.build_flags}
+
 [env:esp32-saturn-debug]
 extends     = esp32, in-saturn, out-debug
 build_src_filter  = ${in-saturn.build_src_filter}  ${out-debug.build_src_filter}
@@ -380,6 +409,11 @@ extends     = esp32, in-wii, out-bt
 build_src_filter  = ${in-wii.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-bt.build_flags}
 
+[env:esp32-wii-br]
+extends     = esp32, in-wii, out-br
+build_src_filter  = ${in-wii.build_src_filter}  ${out-bt.build_src_filter}
+build_flags = ${in-wii.build_flags} ${out-bt.build_flags}
+
 [env:esp32-wii-debug]
 extends     = esp32, in-wii, out-debug
 build_src_filter  = ${in-wii.build_src_filter}  ${out-debug.build_src_filter}
@@ -421,6 +455,11 @@ build_flags = ${common.build_flags} -DGAMEPAD_INPUT=0 -DDEBUG=1
 
 [env:esp32-debug-bt]
 extends     = esp32, in-debug, out-bt
+build_src_filter  = ${in-debug.build_src_filter}  ${out-bt.build_src_filter}
+build_flags = ${in-debug.build_flags} ${out-bt.build_flags}
+
+[env:esp32-debug-br]
+extends     = esp32, in-debug, out-br
 build_src_filter  = ${in-debug.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-bt.build_flags}
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,16 +39,16 @@ framework = arduino
 
 [out-debug]
 build_flags = -DGAMEPAD_OUTPUT=0 -DDEBUG=1
-src_filter = +<gamepad/Debug-Gamepad>
+build_src_filter = +<gamepad/Debug-Gamepad>
 
 [out-radio]
 build_flags = -DGAMEPAD_OUTPUT=1
-src_filter = +<gamepad/Radio-Gamepad>
-lib_deps = tmrh20/RF24@^1.3.9
+build_src_filter = +<gamepad/Radio-Gamepad>
+lib_deps = nRF24/RF24@^1.3.12
 
 [out-usb]
 build_flags = -DGAMEPAD_OUTPUT=2
-src_filter = +<gamepad/USB-Gamepad>
+build_src_filter = +<gamepad/USB-Gamepad>
 framework = arduino
 platform = atmelavr
 extra_scripts = pre:hwids/usb.py
@@ -57,12 +57,12 @@ board_vendor = "8BitDo"
 
 [out-bt]
 build_flags = -DGAMEPAD_OUTPUT=3
-src_filter = +<gamepad/ESP32-BLE-Gamepad>
+build_src_filter = +<gamepad/ESP32-BLE-Gamepad>
 
 [out-usbradio]
 extends     = out-usb, out-radio
 build_flags = -DGAMEPAD_OUTPUT=4
-src_filter = ${out-usb.src_filter} ${out-radio.src_filter}
+build_src_filter = ${out-usb.build_src_filter} ${out-radio.build_src_filter}
 extra_scripts = pre:hwids/usb.py
 board_build.usb_product = "8BitDo SN30 Pro+"
 board_vendor = "8BitDo"
@@ -70,7 +70,7 @@ board_vendor = "8BitDo"
 [out-switchusb]
 # switch only supports 1 controller per dongle
 build_flags = -DGAMEPAD_OUTPUT=5 -DGAMEPAD_COUNT=1
-src_filter = +<gamepad/Switch-USB-Gamepad>
+build_src_filter = +<gamepad/Switch-USB-Gamepad>
 lib_deps = https://github.com/OpenRetroPad/HID
 extra_scripts = pre:hwids/switch.py
 board_build.usb_product = "HORIPAD S"
@@ -80,33 +80,33 @@ board_vendor = "HORI CO.,LTD."
 
 [in-radio]
 extends = out-radio
-src_filter = -<*> +<RadioReceiver.cpp>
+build_src_filter = -<*> +<RadioReceiver.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=1
 
 # this one is a bit crazy, just use esp32-$input-bt directly
 [env:esp32-radio-bt]
 extends     = esp32, in-radio, out-bt
-src_filter  = ${in-radio.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-radio.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-radio.build_flags} ${out-bt.build_flags}
 
 [env:esp32-radio-debug]
 extends     = esp32, in-radio, out-debug
-src_filter  = ${in-radio.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-radio.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-radio.build_flags} ${out-debug.build_flags}
 
 [env:micro-radio-usb]
 extends     = micro, in-radio, out-usb
-src_filter  = ${in-radio.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-radio.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-radio.build_flags} ${out-usb.build_flags}
 
 [env:micro-radio-debug]
 extends     = micro, in-radio, out-debug
-src_filter  = ${in-radio.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-radio.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-radio.build_flags} ${out-debug.build_flags}
 
 [env:micro-radio-switchusb]
 extends     = micro, in-radio, out-switchusb
-src_filter  = ${in-radio.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-radio.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-radio.build_flags} ${out-switchusb.build_flags}
 lib_deps    = ${in-radio.lib_deps}, ${out-switchusb.lib_deps}
 
@@ -115,117 +115,117 @@ lib_deps    = ${in-radio.lib_deps}, ${out-switchusb.lib_deps}
 # snes input
 
 [in-snes]
-src_filter = -<*> +<SnesNes.cpp>
+build_src_filter = -<*> +<SnesNes.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=2
 
 [env:esp32-snes-bt]
 extends     = esp32, in-snes, out-bt
-src_filter  = ${in-snes.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-bt.build_flags}
 
 [env:esp32-snes-debug]
 extends     = esp32, in-snes, out-debug
-src_filter  = ${in-snes.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-debug.build_flags}
 
 [env:micro-snes-usb]
 extends     = micro, in-snes, out-usb
-src_filter  = ${in-snes.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-usb.build_flags}
 
 [env:micro-snes-debug]
 extends     = micro, in-snes, out-debug
-src_filter  = ${in-snes.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-debug.build_flags}
 
 [env:micro-snes-radio]
 extends     = micro, in-snes, out-radio
-src_filter  = ${in-snes.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-radio.build_flags}
 
 [env:micro-snes-usbradio]
 extends     = micro, in-snes, out-usbradio
-src_filter  = ${in-snes.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-usbradio.build_flags}
 
 [env:micro-snes-switchusb]
 extends     = micro, in-snes, out-switchusb
-src_filter  = ${in-snes.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-snes.build_flags} ${out-switchusb.build_flags}
 
 # n64 input
 
 [in-n64-esp32]
-src_filter = -<*> +<N64Esp32.cpp>
+build_src_filter = -<*> +<N64Esp32.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=3 -DGAMEPAD_COUNT=1
 
 [in-n64-micro]
-src_filter = -<*> +<N64Micro.cpp>
+build_src_filter = -<*> +<N64Micro.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=3 -DGAMEPAD_COUNT=1
 lib_deps = https://github.com/OpenRetroPad/Nintendo
 
 [env:esp32-n64-bt]
 extends     = esp32, in-n64-esp32, out-bt
-src_filter  = ${in-n64-esp32.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-n64-esp32.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-n64-esp32.build_flags} ${out-bt.build_flags}
 
 [env:esp32-n64-debug]
 extends     = esp32, in-n64-esp32, out-debug
-src_filter  = ${in-n64-esp32.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-n64-esp32.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-n64-esp32.build_flags} ${out-debug.build_flags}
 
 [env:micro-n64-usb]
 extends     = micro, in-n64-micro, out-usb
-src_filter  = ${in-n64-micro.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-n64-micro.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-n64-micro.build_flags} ${out-usb.build_flags}
 
 [env:micro-n64-debug]
 extends     = micro, in-n64-micro, out-debug
-src_filter  = ${in-n64-micro.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-n64-micro.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-n64-micro.build_flags} ${out-debug.build_flags}
 
 [env:micro-n64-radio]
 extends     = micro, in-n64-micro, out-radio
-src_filter  = ${in-n64-micro.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-n64-micro.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-n64-micro.build_flags} ${out-radio.build_flags}
 lib_deps    = ${in-n64-micro.lib_deps},   ${out-radio.lib_deps}
 
 [env:micro-n64-usbradio]
 extends     = micro, in-n64-micro, out-usbradio
-src_filter  = ${in-n64-micro.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-n64-micro.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-n64-micro.build_flags} ${out-usbradio.build_flags}
 lib_deps    = ${in-n64-micro.lib_deps},   ${out-usbradio.lib_deps}
 
 [env:micro-n64-switchusb]
 extends     = micro, in-n64-micro, out-switchusb
-src_filter  = ${in-n64-micro.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-n64-micro.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-n64-micro.build_flags} ${out-switchusb.build_flags}
 lib_deps    = ${in-n64-micro.lib_deps},   ${out-switchusb.lib_deps}
 
 # genesis input
 
 [in-genesis]
-src_filter = -<*> +<SegaGenesis.cpp>
+build_src_filter = -<*> +<SegaGenesis.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=4
 
 [env:esp32-genesis-bt]
 extends     = esp32, in-genesis, out-bt
-src_filter  = ${in-genesis.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-bt.build_flags}
 
 [env:esp32-genesis-debug]
 extends     = esp32, in-genesis, out-debug
-src_filter  = ${in-genesis.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-debug.build_flags}
 
 [env:micro-genesis-usb]
 extends     = micro, in-genesis, out-usb
-src_filter  = ${in-genesis.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-usb.build_flags}
 
 [env:micro-genesis-debug]
 extends     = micro, in-genesis, out-debug
-src_filter  = ${in-genesis.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-debug.build_flags}
 
 # micro doesn't have enough pins for both radio and 2 gamepads
@@ -233,137 +233,137 @@ build_flags = ${in-genesis.build_flags} ${out-debug.build_flags}
 
 [env:micro-genesis-radio]
 extends     = micro, in-genesis, out-radio
-src_filter  = ${in-genesis.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-radio.build_flags} -DGAMEPAD_COUNT=1
 
 [env:micro-genesis-usbradio]
 extends     = micro, in-genesis, out-usbradio
-src_filter  = ${in-genesis.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-usbradio.build_flags} -DGAMEPAD_COUNT=1
 
 [env:micro-genesis-switchusb]
 extends     = micro, in-genesis, out-switchusb
-src_filter  = ${in-genesis.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-genesis.build_flags} ${out-switchusb.build_flags}
 
 # psx input
 
 [in-psx]
-src_filter = -<*> +<Playstation.cpp>
+build_src_filter = -<*> +<Playstation.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=5 -DGAMEPAD_COUNT=4
 
 [env:esp32-psx-bt]
 extends     = esp32, in-psx, out-bt
-src_filter  = ${in-psx.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-bt.build_flags}
 
 [env:esp32-psx-debug]
 extends     = esp32, in-psx, out-debug
-src_filter  = ${in-psx.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-debug.build_flags}
 
 [env:micro-psx-usb]
 extends     = micro, in-psx, out-usb
-src_filter  = ${in-psx.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-usb.build_flags}
 
 [env:micro-psx-debug]
 extends     = micro, in-psx, out-debug
-src_filter  = ${in-psx.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-debug.build_flags}
 
 [env:micro-psx-radio]
 extends     = micro, in-psx, out-radio
-src_filter  = ${in-psx.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-radio.build_flags}
 
 [env:micro-psx-usbradio]
 extends     = micro, in-psx, out-usbradio
-src_filter  = ${in-psx.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-usbradio.build_flags}
 
 [env:micro-psx-switchusb]
 extends     = micro, in-psx, out-switchusb
-src_filter  = ${in-psx.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-psx.build_flags} ${out-switchusb.build_flags}
 
 # gc input
 
 [in-gc-micro]
-src_filter = -<*> +<N64Micro.cpp>
+build_src_filter = -<*> +<N64Micro.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=5 -DGAMEPAD_COUNT=1 -DGAMECUBE
 lib_deps = https://github.com/OpenRetroPad/Nintendo
 
 [env:micro-gc-usb]
 extends     = micro, in-gc-micro, out-usb
-src_filter  = ${in-gc-micro.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-gc-micro.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-gc-micro.build_flags} ${out-usb.build_flags}
 
 [env:micro-gc-debug]
 extends     = micro, in-gc-micro, out-debug
-src_filter  = ${in-gc-micro.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-gc-micro.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-gc-micro.build_flags} ${out-debug.build_flags}
 
 [env:micro-gc-radio]
 extends     = micro, in-gc-micro, out-radio
-src_filter  = ${in-gc-micro.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-gc-micro.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-gc-micro.build_flags} ${out-radio.build_flags}
 lib_deps    = ${in-gc-micro.lib_deps},   ${out-radio.lib_deps}
 
 [env:micro-gc-usbradio]
 extends     = micro, in-gc-micro, out-usbradio
-src_filter  = ${in-gc-micro.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-gc-micro.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-gc-micro.build_flags} ${out-usbradio.build_flags}
 lib_deps    = ${in-gc-micro.lib_deps},   ${out-usbradio.lib_deps}
 
 [env:micro-gc-switchusb]
 extends     = micro, in-gc-micro, out-switchusb
-src_filter  = ${in-gc-micro.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-gc-micro.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-gc-micro.build_flags} ${out-switchusb.build_flags}
 lib_deps    = ${in-gc-micro.lib_deps},   ${out-switchusb.lib_deps}
 
 # saturn input
 
 [in-saturn]
-src_filter = -<*> +<SegaSaturn.cpp>
+build_src_filter = -<*> +<SegaSaturn.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=6
 lib_deps = watterott/digitalWriteFast @ 1.0.0
 
 [env:esp32-saturn-bt]
 extends     = esp32, in-saturn, out-bt
-src_filter  = ${in-saturn.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-bt.build_flags}
 
 [env:esp32-saturn-debug]
 extends     = esp32, in-saturn, out-debug
-src_filter  = ${in-saturn.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-debug.build_flags}
 
 [env:micro-saturn-usb]
 extends     = micro, in-saturn, out-usb
-src_filter  = ${in-saturn.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-usb.build_flags}
 
 [env:micro-saturn-debug]
 extends     = micro, in-saturn, out-debug
-src_filter  = ${in-saturn.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-debug.build_flags}
 
 [env:micro-saturn-radio]
 extends     = micro, in-saturn, out-radio
-src_filter  = ${in-saturn.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-radio.build_flags}
 lib_deps    = ${in-saturn.lib_deps},   ${out-radio.lib_deps}
 
 [env:micro-saturn-usbradio]
 extends     = micro, in-saturn, out-usbradio
-src_filter  = ${in-saturn.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-usbradio.build_flags}
 lib_deps    = ${in-saturn.lib_deps},   ${out-usbradio.lib_deps}
 
 [env:micro-saturn-switchusb]
 extends     = micro, in-saturn, out-switchusb
-src_filter  = ${in-saturn.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-saturn.build_flags} ${out-switchusb.build_flags}
 lib_deps    = ${in-saturn.lib_deps},   ${out-switchusb.lib_deps}
 
@@ -371,103 +371,103 @@ lib_deps    = ${in-saturn.lib_deps},   ${out-switchusb.lib_deps}
 # wii input
 
 [in-wii]
-src_filter = -<*> +<WiiExtension.cpp>
+build_src_filter = -<*> +<WiiExtension.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=7 -DGAMEPAD_COUNT=1
-lib_deps = dmadison/Nintendo Extension Ctrl @ 0.8.1
+lib_deps = dmadison/Nintendo Extension Ctrl @ 0.8.3
 
 [env:esp32-wii-bt]
 extends     = esp32, in-wii, out-bt
-src_filter  = ${in-wii.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-bt.build_flags}
 
 [env:esp32-wii-debug]
 extends     = esp32, in-wii, out-debug
-src_filter  = ${in-wii.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-debug.build_flags}
 
 [env:micro-wii-usb]
 extends     = micro, in-wii, out-usb
-src_filter  = ${in-wii.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-usb.build_flags}
 
 [env:micro-wii-debug]
 extends     = micro, in-wii, out-debug
-src_filter  = ${in-wii.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-debug.build_flags}
 
 [env:micro-wii-radio]
 extends     = micro, in-wii, out-radio
-src_filter  = ${in-wii.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-radio.build_flags}
 lib_deps    = ${in-wii.lib_deps},   ${out-radio.lib_deps}
 
 [env:micro-wii-usbradio]
 extends     = micro, in-wii, out-usbradio
-src_filter  = ${in-wii.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-usbradio.build_flags}
 lib_deps    = ${in-wii.lib_deps},   ${out-usbradio.lib_deps}
 
 [env:micro-wii-switchusb]
 extends     = micro, in-wii, out-switchusb
-src_filter  = ${in-wii.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-wii.build_flags} ${out-switchusb.build_flags}
 lib_deps    = ${in-wii.lib_deps},   ${out-switchusb.lib_deps}
 
 # debug input
 
 [in-debug]
-src_filter = -<*> +<Debug.cpp>
+build_src_filter = -<*> +<Debug.cpp>
 build_flags = ${common.build_flags} -DGAMEPAD_INPUT=0 -DDEBUG=1
 
 [env:esp32-debug-bt]
 extends     = esp32, in-debug, out-bt
-src_filter  = ${in-debug.src_filter}  ${out-bt.src_filter}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-bt.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-bt.build_flags}
 
 [env:esp32-debug-debug]
 extends     = esp32, in-debug, out-debug
-src_filter  = ${in-debug.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-debug.build_flags}
 
 [env:micro-debug-usb]
 extends     = micro, in-debug, out-usb
-src_filter  = ${in-debug.src_filter}  ${out-usb.src_filter}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-usb.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-usb.build_flags}
 
 [env:micro-debug-debug]
 extends     = micro, in-debug, out-debug
-src_filter  = ${in-debug.src_filter}  ${out-debug.src_filter}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-debug.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-debug.build_flags}
 
 [env:micro-debug-radio]
 extends     = micro, in-debug, out-radio
-src_filter  = ${in-debug.src_filter}  ${out-radio.src_filter}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-radio.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-radio.build_flags}
 
 [env:micro-debug-usbradio]
 extends     = micro, in-debug, out-usbradio
-src_filter  = ${in-debug.src_filter}  ${out-usbradio.src_filter}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-usbradio.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-usbradio.build_flags}
 
 [env:micro-debug-switchusb]
 extends     = micro, in-debug, out-switchusb
-src_filter  = ${in-debug.src_filter}  ${out-switchusb.src_filter}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-switchusb.build_src_filter}
 build_flags = ${in-debug.build_flags} ${out-switchusb.build_flags}
 
 # OhmMeter utility
 
 [ohm]
-src_filter = -<*> +<OhmMeter.cpp>
+build_src_filter = -<*> +<OhmMeter.cpp>
 
 [env:esp32-ohm]
 extends     = esp32, ohm
-src_filter  = ${ohm.src_filter}
+build_src_filter  = ${ohm.build_src_filter}
 
 [env:micro-ohm]
 extends     = micro, ohm
-src_filter  = ${ohm.src_filter}
+build_src_filter  = ${ohm.build_src_filter}
 
 #[env:native]
-#src_filter = -<*> +<test_N64Esp32.cpp>
+#build_src_filter = -<*> +<test_N64Esp32.cpp>
 #platform = native
 #test_ignore = test_embedded

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,7 +60,7 @@ build_flags = -DGAMEPAD_OUTPUT=3
 build_src_filter = +<gamepad/ESP32-BLE-Gamepad>
 
 [out-br]
-build_flags = -DGAMEPAD_OUTPUT=3 -D BLUERETRO_MAPPING
+build_flags = -D BLUERETRO_MAPPING -DGAMEPAD_OUTPUT=3
 build_src_filter = +<gamepad/ESP32-BLE-Gamepad>
 
 [out-usbradio]
@@ -129,8 +129,8 @@ build_flags = ${in-snes.build_flags} ${out-bt.build_flags}
 
 [env:esp32-snes-br]
 extends     = esp32, in-snes, out-br
-build_src_filter  = ${in-snes.build_src_filter}  ${out-bt.build_src_filter}
-build_flags = ${in-snes.build_flags} ${out-bt.build_flags}
+build_src_filter  = ${in-snes.build_src_filter}  ${out-br.build_src_filter}
+build_flags = ${in-snes.build_flags} ${out-br.build_flags}
 
 [env:esp32-snes-debug]
 extends     = esp32, in-snes, out-debug
@@ -180,8 +180,8 @@ build_flags = ${in-n64-esp32.build_flags} ${out-bt.build_flags}
 
 [env:esp32-n64-br]
 extends     = esp32, in-n64-esp32, out-br
-build_src_filter  = ${in-n64-esp32.build_src_filter}  ${out-bt.build_src_filter}
-build_flags = ${in-n64-esp32.build_flags} ${out-bt.build_flags}
+build_src_filter  = ${in-n64-esp32.build_src_filter}  ${out-br.build_src_filter}
+build_flags = ${in-n64-esp32.build_flags} ${out-br.build_flags}
 
 [env:esp32-n64-debug]
 extends     = esp32, in-n64-esp32, out-debug
@@ -229,8 +229,8 @@ build_flags = ${in-genesis.build_flags} ${out-bt.build_flags}
 
 [env:esp32-genesis-br]
 extends     = esp32, in-genesis, out-br
-build_src_filter  = ${in-genesis.build_src_filter}  ${out-bt.build_src_filter}
-build_flags = ${in-genesis.build_flags} ${out-bt.build_flags}
+build_src_filter  = ${in-genesis.build_src_filter}  ${out-br.build_src_filter}
+build_flags = ${in-genesis.build_flags} ${out-br.build_flags}
 
 [env:esp32-genesis-debug]
 extends     = esp32, in-genesis, out-debug
@@ -278,8 +278,8 @@ build_flags = ${in-psx.build_flags} ${out-bt.build_flags}
 
 [env:esp32-psx-br]
 extends     = esp32, in-psx, out-br
-build_src_filter  = ${in-psx.build_src_filter}  ${out-bt.build_src_filter}
-build_flags = ${in-psx.build_flags} ${out-bt.build_flags}
+build_src_filter  = ${in-psx.build_src_filter}  ${out-br.build_src_filter}
+build_flags = ${in-psx.build_flags} ${out-br.build_flags}
 
 [env:esp32-psx-debug]
 extends     = esp32, in-psx, out-debug
@@ -360,8 +360,8 @@ build_flags = ${in-saturn.build_flags} ${out-bt.build_flags}
 
 [env:esp32-saturn-br]
 extends     = esp32, in-saturn, out-bt
-build_src_filter  = ${in-saturn.build_src_filter}  ${out-bt.build_src_filter}
-build_flags = ${in-saturn.build_flags} ${out-bt.build_flags}
+build_src_filter  = ${in-saturn.build_src_filter}  ${out-br.build_src_filter}
+build_flags = ${in-saturn.build_flags} ${out-br.build_flags}
 
 [env:esp32-saturn-debug]
 extends     = esp32, in-saturn, out-debug
@@ -411,8 +411,8 @@ build_flags = ${in-wii.build_flags} ${out-bt.build_flags}
 
 [env:esp32-wii-br]
 extends     = esp32, in-wii, out-br
-build_src_filter  = ${in-wii.build_src_filter}  ${out-bt.build_src_filter}
-build_flags = ${in-wii.build_flags} ${out-bt.build_flags}
+build_src_filter  = ${in-wii.build_src_filter}  ${out-br.build_src_filter}
+build_flags = ${in-wii.build_flags} ${out-br.build_flags}
 
 [env:esp32-wii-debug]
 extends     = esp32, in-wii, out-debug
@@ -460,8 +460,8 @@ build_flags = ${in-debug.build_flags} ${out-bt.build_flags}
 
 [env:esp32-debug-br]
 extends     = esp32, in-debug, out-br
-build_src_filter  = ${in-debug.build_src_filter}  ${out-bt.build_src_filter}
-build_flags = ${in-debug.build_flags} ${out-bt.build_flags}
+build_src_filter  = ${in-debug.build_src_filter}  ${out-br.build_src_filter}
+build_flags = ${in-debug.build_flags} ${out-br.build_flags}
 
 [env:esp32-debug-debug]
 extends     = esp32, in-debug, out-debug

--- a/src/N64Esp32.cpp
+++ b/src/N64Esp32.cpp
@@ -342,6 +342,7 @@ void populateControllerStruct(ControllerData *data) {
 ControllerData controller;
 
 void setup() {
+	setupBrLed();
 #ifdef DEBUG
 	Serial.begin(115200);
 	delay(5000);

--- a/src/Playstation.cpp
+++ b/src/Playstation.cpp
@@ -301,6 +301,7 @@ uint8_t shift(uint8_t _dataOut)	 // Does the actual shifting, both in and out si
 }
 
 void setup() {
+	setupBrLed();
 #ifdef DEBUG
 	Serial.begin(115200);
 #endif

--- a/src/Playstation.cpp
+++ b/src/Playstation.cpp
@@ -28,6 +28,11 @@ PIN # USAGE (colors from my extension cable, check your own)
 #define ATT1 OR_PIN_4
 #define CLK1 OR_PIN_5
 
+#ifdef BLUERETRO_MAPPING
+#undef ATT1
+#define ATT1 OR_PIN_10
+#endif
+
 #if defined(ARDUINO_ARCH_ESP32)
 
 #define CTRL_BYTE_DELAY 18

--- a/src/SegaGenesis.cpp
+++ b/src/SegaGenesis.cpp
@@ -70,11 +70,27 @@ static const int DATA_PIN[GAMEPAD_COUNT][PIN_COUNT] = {
 #define OPT_PIN_READ1(X) (digitalRead(DATA_PIN[c][X]))
 #define OPT_PIN_READ2(X) (digitalRead(DATA_PIN[c][X]))
 
+#define P1_5 OR_PIN_4
+#define P1_6 OR_PIN_6
+#define P2_5 OR_PIN_14
+#define P2_6 OR_PIN_15
+
+#ifdef BLUERETRO_MAPPING
+#undef P1_5
+#undef P1_6
+#undef P2_5
+#undef P2_6
+#define P1_5 OR_PIN_10
+#define P1_6 ALT_PIN_1
+#define P2_5 ALT_PIN_3
+#define P2_6 ALT_PIN_4
+#endif
+
 //individual data pin for each controller
 static const int DATA_PIN[GAMEPAD_COUNT][PIN_COUNT] = {
-	{OR_PIN_1, OR_PIN_11, OR_PIN_2, OR_PIN_3, OR_PIN_4, OR_PIN_6},
+	{OR_PIN_1, OR_PIN_11, OR_PIN_2, OR_PIN_3, P1_5, P1_6},
 #if GAMEPAD_COUNT > 1
-	{OR_PIN_18, OR_PIN_19, OR_PIN_20, OR_PIN_21, OR_PIN_14, OR_PIN_15},
+	{OR_PIN_18, OR_PIN_19, OR_PIN_20, OR_PIN_21, P2_5, P2_6},
 #endif
 };
 

--- a/src/SegaGenesis.cpp
+++ b/src/SegaGenesis.cpp
@@ -25,6 +25,8 @@ PIN # USAGE
 
 #include "gamepad/Gamepad.h"
 
+#include "util.cpp"
+
 enum
 {
 	// this is the button mapping, change as you wish
@@ -45,10 +47,29 @@ enum
 
 #include "pins.h"
 
+#define P1_5 OR_PIN_4
+#define P1_6 OR_PIN_6
+#define P2_5 OR_PIN_14
+#define P2_6 OR_PIN_15
+#define P2_7 OR_PIN_7
+
+#ifdef BLUERETRO_MAPPING
+#undef P1_5
+#undef P1_6
+#undef P2_5
+#undef P2_6
+#undef P2_7
+#define P1_5 OR_PIN_10
+#define P1_6 ALT_PIN_1
+#define P2_5 ALT_PIN_3
+#define P2_6 ALT_PIN_4
+#define P2_7 ALT_PIN_2
+#endif
+
 static const int DATA_PIN_SELECT[GAMEPAD_COUNT] = {
 	OR_PIN_5,
 #if GAMEPAD_COUNT > 1
-	OR_PIN_7,
+	P2_7,
 #endif
 };
 
@@ -69,22 +90,6 @@ static const int DATA_PIN[GAMEPAD_COUNT][PIN_COUNT] = {
 
 #define OPT_PIN_READ1(X) (digitalRead(DATA_PIN[c][X]))
 #define OPT_PIN_READ2(X) (digitalRead(DATA_PIN[c][X]))
-
-#define P1_5 OR_PIN_4
-#define P1_6 OR_PIN_6
-#define P2_5 OR_PIN_14
-#define P2_6 OR_PIN_15
-
-#ifdef BLUERETRO_MAPPING
-#undef P1_5
-#undef P1_6
-#undef P2_5
-#undef P2_6
-#define P1_5 OR_PIN_10
-#define P1_6 ALT_PIN_1
-#define P2_5 ALT_PIN_3
-#define P2_6 ALT_PIN_4
-#endif
 
 //individual data pin for each controller
 static const int DATA_PIN[GAMEPAD_COUNT][PIN_COUNT] = {
@@ -378,6 +383,7 @@ void controllerChanged(const int c) {
 }
 
 void setup() {
+	setupBrLed();
 #ifdef DEBUG
 	Serial.begin(115200);
 #endif

--- a/src/SegaSaturn.cpp
+++ b/src/SegaSaturn.cpp
@@ -66,6 +66,13 @@ NOTE: The receiver of the Retro Bit 2.4GHz controller needs to be plugged
 
 #endif
 
+#ifdef BLUERETRO_MAPPING
+#undef P1_6
+#undef PX_4
+#define P1_6 ALT_PIN_1
+#define PX_4 ALT_PIN_2
+#endif
+
 // Set up USB HID gamepads
 GAMEPAD_CLASS gamepad;
 

--- a/src/SegaSaturn.cpp
+++ b/src/SegaSaturn.cpp
@@ -45,6 +45,7 @@ NOTE: The receiver of the Retro Bit 2.4GHz controller needs to be plugged
 //#define RETROBIT_WL
 
 #include "pins.h"
+#include "util.cpp"
 
 // pins
 #define P1_2 OR_PIN_2
@@ -223,6 +224,7 @@ void read4() {
 }
 
 void setup() {
+	setupBrLed();
 	gamepad.begin();
 
 	// Set P1 data pins  as inputs and enable pull-up resistors

--- a/src/SnesNes.cpp
+++ b/src/SnesNes.cpp
@@ -7,6 +7,7 @@
 #define BUTTON_COUNT 12	 // SNES has 12, NES only has 8
 
 #include "pins.h"
+#include "util.cpp"
 
 //shared pins between all controllers
 static const int LATCH_PIN = OR_PIN_1;	// brown
@@ -212,6 +213,7 @@ void controllerChangedDebug(const int c) {
 #endif	// DEBUG
 
 void setup() {
+	setupBrLed();
 	bool allNes = true;
 #ifdef DEBUG
 	delay(5000);

--- a/src/SnesNes.cpp
+++ b/src/SnesNes.cpp
@@ -12,17 +12,29 @@
 static const int LATCH_PIN = OR_PIN_1;	// brown
 static const int CLOCK_PIN = OR_PIN_2;	// white
 
+#define DATA_P1 OR_PIN_3
+#define DATA_P2 OR_PIN_4
+#define DATA_P3 OR_PIN_5
+#define DATA_P4 OR_PIN_6
+
+#ifdef BLUERETRO_MAPPING
+#undef DATA_P2
+#undef DATA_P4
+#define DATA_P2 OR_PIN_10
+#define DATA_P4 OR_PIN_11
+#endif
+
 //individual data pin for each controller
 static const int DATA_PIN[GAMEPAD_COUNT] = {
-	OR_PIN_3,
+	DATA_P1,
 #if GAMEPAD_COUNT > 1
-	OR_PIN_4,
+	DATA_P2,
 #endif
 #if GAMEPAD_COUNT > 2
-	OR_PIN_5,
+	DATA_P3,
 #endif
 #if GAMEPAD_COUNT > 3
-	OR_PIN_6,
+	DATA_P4,
 #endif
 };
 // power red, ground black

--- a/src/WiiExtension.cpp
+++ b/src/WiiExtension.cpp
@@ -44,13 +44,13 @@ ExtensionPort port;	 // Port for communicating with extension controllers
 Nunchuk::Shared nchuk(port);			  // Read Nunchuk formatted data from the port
 ClassicController::Shared classic(port);  // Read Classic Controller formatted data from the port
 
-ExtensionController* controllers[] = {
+NintendoExtensionCtrl::ExtensionController* controllers[] = {
 	// Array of available controllers, for controller-specific init
 	&nchuk,
 	&classic,
 };
 
-const int NumControllers = sizeof(controllers) / sizeof(ExtensionController*);	// # of controllers, auto-generated
+const int NumControllers = sizeof(controllers) / sizeof(NintendoExtensionCtrl::ExtensionController*);	// # of controllers, auto-generated
 
 void (*controllerChanged)();
 

--- a/src/WiiExtension.cpp
+++ b/src/WiiExtension.cpp
@@ -146,6 +146,7 @@ boolean connectController() {
 }
 
 void setup() {
+	setupBrLed();
 	gamepad.begin();
 	port.begin();  // init I2C
 

--- a/src/pins.h
+++ b/src/pins.h
@@ -24,7 +24,13 @@
 #define OR_PIN_19 26
 #define OR_PIN_20 25
 #define OR_PIN_21 33
-// 23
+
+#ifdef BLUERETRO_MAPPING
+#define ALT_PIN_1 23 //XT pins for BlueRetro mapping use
+#define ALT_PIN_2 5  // pwm at boot
+#define ALT_PIN_3 34 // input only
+#define ALT_PIN_4 36 // input only
+#endif
 #else
 // micro
 #define OR_PIN_1 1

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -95,3 +95,13 @@ inline uint8_t translateTrigger(long v) {
 	return translate(v, TRIGGER_MIN_IN, TRIGGER_MAX_IN, TRIGGER_MIN, TRIGGER_MAX);
 #endif
 }
+
+#ifdef BLUERETRO_MAPPING
+void setupBrLed()
+{
+	pinMode(17, OUTPUT);
+	digitalWrite(17, LOW);
+}
+#else
+void setupBrLed(){}
+#endif


### PR DESCRIPTION
Hi
Cleaned up PR which updates libraries to fix compilation issues, and adds a BR build option with alternate pin mappings to avoid conflicts with missing pins on BR hardware

1. Update "platformio.ini" to fix compilation issues
Account name for "RF24" library has changed
"src_filter" deprecated, now "build_src_filter"
Nintendo Extension Ctrl @ 0.8.1 no longer available, switch to 0.8.3
Minor modification to WiiExtension.cpp required in consequence

2. Add "/.vscode" to ".gitignore"

3. Define ALT_PINS to make use of spare ESP32 pins in place of missing pins on BlueRetro interfaces
Add out-br build options to platformio.ini, same as out-bt but with BLURETRO_MAPPING flag applied
BLUERETRO_MAPPING flag alterations, when defined:
Playstation ATT Pin changed from OR_PIN_4 (15) to OR_PIN_10 (32)
SnesNes Data_P2 pin changed from OR_PIN_4 (15) to OR_PIN_10 (32)
SnesNes Data_P4 pin changed from OR_PIN_6 (2) to OR_PIN_11 (18)
Saturn P1_6 changed from OR_PIN_4 to ALT_PIN_1 (23)
Saturn PX_4 changed from OR_PIN_6 to ALT_PIN_2 (5)
Genesis P1_5 changed from OR_PIN_4 (15) to OR_PIN_10 (32)
Genesis P1_6 changed from OR_PIN_6 (2) to ALT_PIN_1 (23)
Genesis P2_5 changed from OR_PIN_14 (12) to ALT_PIN_3 (34)
Genesis P2_6 changed from OR_PIN_15 (14) to ALT_PIN_4 (36)